### PR TITLE
Add an example of configuring build arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ jobs:
           folder: src/docker
           dockerfile: ../../dockerfiles/Dockerfile
           branch: main
-	  build_args: '[{"arg_one":"value_one"}, {"arg_two":"value_two"}]'
+          build_args: '[{"arg_one":"value_one"}, {"arg_two":"value_two"}]'
 ```
 
 # Contributing

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ jobs:
           folder: src/docker
           dockerfile: ../../dockerfiles/Dockerfile
           branch: main
+	  build_args: '[{"arg_one":"value_one"}, {"arg_two":"value_two"}]'
 ```
 
 # Contributing


### PR DESCRIPTION
The current documentation is unclear on how to add a build argument to the workflow. Making an assumption that it should be in a 'key=value' format in the yaml results in hard to understand errors from jq such as `parse error: Invalid numeric literal at EOF at line 1, column 12` 

This PR adds an example to make it more clear that the Action expects build arguments to be passed as an array of JSON objects